### PR TITLE
Use secondary indices for expiration, not expensive key walking operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ module.exports = function(connect) {
     this.bucket = options.bucket || '_sessions';
     this.dbOptions = { encodeUri: true, debug: false };
     
-    if (options.reapInterval > 0) {
+    if (require('cluster').isMaster && options.reapInterval > 0) {
       setInterval(function() {
         reapSessions(this);
       }.bind(this), options.reapInterval);
@@ -64,7 +64,7 @@ module.exports = function(connect) {
       .run(function(err, expired) {
         if (!err && expired && expired.unshift) {
           expired.forEach(function(e) {
-            self.client.remove(self.bucket, e);
+            self.client.remove(self.bucket, e, self.dbOptions);
           });
         }
       });


### PR DESCRIPTION
I've learned the hard way that you really should not walk all the keys in your Riak cluster.

This change implements expiration using a binary secondary index.  This is available if you configure your Riak 1.0+ backend to use eleveldb.

This change also disables the length() method, as this is expensive to calculate in Riak for the same reasons.
